### PR TITLE
Correction in Language options

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -16,7 +16,7 @@
         <item>English</item>
         <item>Česky</item>
         <item>हिंदी</item>
-        <item>中国人</item>
+        <item>简体中文</item>
     </string-array>
 
     <string-array name="language_values" translatable="false">


### PR DESCRIPTION
Sorry to ping again 

I guess you directly translate word "Chinese" , causing the translator thought that you want to express "Chinese People" (中国人)

Here's some extra info, hope it is helpful for you
zh-CN/zh-SG is Chinese-Simplified（简体中文）which is mainly used in China mainland and Singapore;
zh-TW and zh-MO is Chinese-Traditional（繁体中文 or 正体中文）which is mainly used in Taiwan, Hongkong or Macau of China

Thank you again for your patience!